### PR TITLE
Update 2020-08-29.md

### DIFF
--- a/meetings/2020-08-29.md
+++ b/meetings/2020-08-29.md
@@ -140,6 +140,7 @@ Meeting logistics will be emailed to attendees individually once your registrati
 1. 徐君（英特尔） Jun Xu (Intel)
 1. 王宁（英特尔） Ning Wang（Intel）
 1. 李争（腾讯）Zheng Li（Tencent）
+1. 单华琦（中国移动）Huaqi Shan (CMCC)
 
 ## 其他 Logistics
 


### PR DESCRIPTION
Hello, 

I’d like to register the W3C Chinese Web Interest Group (CWIG) virtual meeting on WebAssembly, on 29 August 2020.